### PR TITLE
minor parser improvements

### DIFF
--- a/engine/dune
+++ b/engine/dune
@@ -1,4 +1,4 @@
 (executable
  (name main)
- (libraries core batteries)
+ (libraries batteries)
  )

--- a/engine/main.ml
+++ b/engine/main.ml
@@ -1,6 +1,4 @@
 [@@@ warning "-30"]
-open BatIO
-
 open BatList
 
 type source_program  = {
@@ -103,8 +101,8 @@ let tokenize lsp =
 
 type eng = { stm: string; pi: bool }
 
-let rec parse_lambda lsp =
-  let print op = BatIO.write_string stdout (op^"\n")
+let rec parse lsp =
+  let print op = Printf.printf "%s\n%!" op
   in
   let advance_two_sexpr lsp = (* helper function to read two sexpr at a time *)
     let s1, rem = parse_lambda lsp in

--- a/engine/main.ml
+++ b/engine/main.ml
@@ -253,3 +253,10 @@ let rec parse_lambda lsp =
      end
   | _ -> assert false
 
+let () =
+  ignore target_example;
+  let target_example = BatFile.with_file_in Sys.argv.(1) BatIO.read_all in
+  let tk = tokenize target_example in
+  let sexpr, tl = parse_lambda tk in
+  ignore sexpr;
+  if tl <> [] then Printf.eprintf "unparsed: %S\n%!" (String.concat " " tl)

--- a/example1.lambda
+++ b/example1.lambda
@@ -17,7 +17,7 @@
                            (if (!= match/1220 1) (exit 4)
                              (let (match/1224 =a (field 1 lt/1212))
                                (if match/1224
-                                 (if (field 1 match/1224) (exit 1) "K1 1")
+                                 (if (field 1 match/1224) (exit 1) "K1:1")
                                  (exit 1))))
                            (let (match/1221 =a (field 1 lt/1212))
                              (if match/1221
@@ -35,22 +35,22 @@
                            (switch match/1230
                             case tag 0:
                              (if (!= (field 0 match/1230) 1)
-                               (if (field 1 match/1229) (exit 1) "K1 _")
-                               (if (field 1 match/1229) (exit 1) "K1 1"))
+                               (if (field 1 match/1229) (exit 1) "K1:_")
+                               (if (field 1 match/1229) (exit 1) "K1:1"))
                             default: (exit 3)))
                          (exit 1))))
                   with (3)
                    (switch match/1219
                     case tag 1:
                      (if (!= (field 0 match/1219) 0)
-                       (if (field 1 (field 1 lt/1212)) (exit 1) "K2 _")
-                       (if (field 1 (field 1 lt/1212)) (exit 1) "K2 false"))
+                       (if (field 1 (field 1 lt/1212)) (exit 1) "K2:_")
+                       (if (field 1 (field 1 lt/1212)) (exit 1) "K2:false"))
                     default: (exit 2)))
                 with (2)
                  (let (match/1241 =a (field 1 lt/1212))
                    (switch* (field 0 match/1241)
                     case int 0: (exit 1)
-                    case tag 1: (if (field 1 match/1241) (exit 1) "K2 _")
+                    case tag 1: (if (field 1 match/1241) (exit 1) "K2:_")
                     case tag 2: (exit 1)))))
              (exit 1))
           with (1) "[_, _]")))


### PR DESCRIPTION
The resulting parser cannot quite parse `example1.lambda` (it gets stuck on `apply` which should go in TBlackbox, but I'm not sure how to do this without teaching the grammar/parser how to parse arbitrary expressions... Probably use a different format of less-structured but well-parenthesized sexprs inside blackboxes.)