### PR TITLE
Parser for the source language

### DIFF
--- a/engine/ast.ml
+++ b/engine/ast.ml
@@ -1,7 +1,6 @@
 [@@@ warning "-30"]
 
 type source_program  = {
-  scrutinee: variable;
   clauses: clause list;
 }
 and
@@ -17,6 +16,7 @@ and
   | Variant of string
   | Int of int
   | Bool of bool
+  | String of string
   | Tuple
   | Nil
   | Cons

--- a/engine/dune
+++ b/engine/dune
@@ -9,5 +9,5 @@
 
 (executable
  (name main)
- (libraries batteries)
+ (libraries batteries ocaml-compiler-libs.common ocaml-migrate-parsetree)
  )

--- a/engine/dune-project
+++ b/engine/dune-project
@@ -1,2 +1,6 @@
-(lang dune 1.2)
+(lang dune 1.11)
 (using menhir 2.0)
+
+(wrapped_executables true)
+; wrapped_executables avoids a name conflict between our Lexer module
+; and the compiler's Lexer module

--- a/engine/main.ml
+++ b/engine/main.ml
@@ -304,3 +304,7 @@ let empty_environment () =
 let () =
   let _ = sym_exec example_ast [] (empty_environment ())  in
   ()
+
+let () =
+  if Array.length Sys.argv >= 2 then
+    Ocaml_parser.try_parse Sys.argv.(2)

--- a/engine/main.ml
+++ b/engine/main.ml
@@ -307,4 +307,12 @@ let () =
 
 let () =
   if Array.length Sys.argv >= 2 then
-    Ocaml_parser.try_parse Sys.argv.(2)
+    let file = Sys.argv.(2) in
+    match Ocaml_parser.ocaml_of_file file with
+    | Error err -> Ocaml_parser.handle_error err
+    | Ok ocaml_ast ->
+    match Ocaml_parser.ast_of_ocaml ~file ocaml_ast with
+    | exception exn -> Ocaml_parser.handle_error exn
+    | ast ->
+    ignore ast;
+    Format.printf "Source input:@.%a@." Ocaml_parser.pp_ocaml_program ocaml_ast;

--- a/engine/ocaml_parser.ml
+++ b/engine/ocaml_parser.ml
@@ -1,19 +1,165 @@
 module Ocaml_ast = Migrate_parsetree.Ast_408
 
-let parse_implementation lexbuf : Ocaml_ast.Parsetree.structure =
-  let ast =
-    try Ocaml_common.Parse.implementation lexbuf
-    with exn ->
-      Ocaml_common.Location.report_exception Format.err_formatter exn;
-      exit 2 in
-  let convert =
-    let open Migrate_parsetree.Versions in
-    (migrate ocaml_current ocaml_408).copy_structure in
-  convert ast
+type ocaml_program = Ocaml_ast.Parsetree.structure
 
-let try_parse file =
+let parse_implementation lexbuf =
+  match Ocaml_common.Parse.implementation lexbuf with
+  | exception exn -> Error exn
+  | ast ->
+    let convert =
+      let open Migrate_parsetree.Versions in
+      (migrate ocaml_current ocaml_408).copy_structure in
+    Ok (convert ast)
+
+let handle_error exn =
+  Ocaml_common.Location.report_exception Format.err_formatter exn;
+  exit 2
+
+let ocaml_of_file file =
   let input = open_in file in
   Fun.protect ~finally:(fun () -> close_in input) @@ fun () ->
   let lexbuf = Lexing.from_channel input in
   Ocaml_ast.Location.init lexbuf file;
-  ignore (parse_implementation lexbuf)
+  Ocaml_ast.Location.input_name := file;
+  Ocaml_ast.Location.input_lexbuf := Some lexbuf;
+  parse_implementation lexbuf
+
+let pp_ocaml_program ppf (prog : ocaml_program) =
+  let convert =
+    let open Migrate_parsetree.Versions in
+    (migrate ocaml_408 ocaml_current).copy_structure in
+  Ocaml_common.Pprintast.structure ppf (convert prog)
+
+let pp_ocaml_expr ppf (exp : Ocaml_ast.Parsetree.expression) =
+  let convert =
+    let open Migrate_parsetree.Versions in
+    (migrate ocaml_408 ocaml_current).copy_expression in
+  Ocaml_common.Pprintast.expression ppf (convert exp)
+
+module Location = Ocaml_ast.Location
+open Ocaml_ast.Parsetree
+
+let error_at loc fmt =
+  Location.raise_errorf ~loc ("OCaml->AST conversion error: " ^^ fmt)
+
+open Ast
+
+let rec ast_of_ocaml ~file (prog : ocaml_program) : source_program =
+  let definition =
+    match prog with
+    | [] | _ :: _ :: _ ->
+       error_at (Location.in_file file)
+         "a single declaration was expected"
+    | [def] ->
+       def in
+  let definition_body =
+    match definition.pstr_desc with
+    | Pstr_value (_, [binding]) ->
+       binding.pvb_expr
+    | _ ->
+       error_at definition.pstr_loc
+         "a value declaration was expected"
+  in
+  let cases =
+    match definition_body.pexp_desc with
+    | Pexp_function cases ->
+       cases
+    | Pexp_fun (_arg_label, _default_val, arg, body) ->
+       let error loc = error_at loc "(fun x -> match x with ...) expected" in
+       let param = bound_var_of_ocaml arg in
+       let cases = match body.pexp_desc with
+         | Pexp_match ({ pexp_desc = Pexp_ident id; pexp_loc; _ }, cases) ->
+            if not (String.equal (ident_of_ocaml id) param)
+            then error pexp_loc;
+            cases
+         | _ -> error body.pexp_loc
+       in cases
+    | _ ->
+       error_at definition_body.pexp_loc
+         "expected (function ...) or (fun x -> match x with ...)"
+  in
+  {
+    clauses = List.map clause_of_ocaml cases;
+  }
+
+and clause_of_ocaml { pc_lhs = pattern; pc_guard = guard; pc_rhs = expr } : clause =
+  begin match guard with
+  | None -> ()
+  | Some guard ->
+     Location.alert ~kind:"Warning" guard.pexp_loc "Ignored pattern guard";
+  end;
+  let pattern = pattern_of_ocaml pattern in
+  let expr = blackbox_of_ocaml expr in
+  (pattern, expr)
+
+and pattern_of_ocaml p : Ast.pattern =
+  let error fmt = error_at p.ppat_loc fmt in
+  match p.ppat_desc with
+  | Ppat_any ->
+     Wildcard
+  | Ppat_var { Location.txt = var; _ } ->
+     As (Wildcard, var)
+  | Ppat_alias (p, { Location.txt = var; _ }) ->
+     As (pattern_of_ocaml p, var)
+  | Ppat_or (p1, p2) ->
+     Or (pattern_of_ocaml p1, pattern_of_ocaml p2)
+  | Ppat_constant cst ->
+     let cstr: constructor =
+       match constant_of_ocaml (Location.mkloc cst p.ppat_loc) with
+       | `Int n -> Int n
+       | `String s -> String s
+     in
+     Constructor (cstr, [])
+  | Ppat_construct (cstr, params) ->
+     let cstr = constructor_of_ocaml cstr in
+     let args = match params with
+       | None ->
+          []
+       | Some { ppat_desc = Ppat_tuple args; _ } ->
+          List.map pattern_of_ocaml args
+       | Some p ->
+          [pattern_of_ocaml p]
+     in
+     Constructor (cstr, args)
+  | Ppat_tuple args ->
+     let args = List.map pattern_of_ocaml args in
+     Constructor (Tuple, args)
+  | _ -> error "unsupported pattern"
+
+and ident_of_ocaml lid =
+  let error fmt = error_at lid.Location.loc fmt in
+  let open Ocaml_ast.Longident in
+  match lid.Location.txt with
+  | Ldot _ | Lapply _ -> error "unsupported identifier"
+  | Lident id -> id
+
+and constructor_of_ocaml cstr =
+  match ident_of_ocaml cstr with
+  | "true" -> Bool true
+  | "false" -> Bool false
+  | "[]" -> Nil
+  | "::" -> Cons
+  | variant -> Variant variant
+
+and constant_of_ocaml (cst : constant Location.loc) =
+  let error fmt = error_at cst.Location.loc fmt in
+  match cst.Location.txt with
+  | Pconst_integer (n, None) ->
+     `Int (try int_of_string n
+           with _exn -> error "invalid integer literal")
+  | Pconst_string (str, _) ->
+     `String str
+  | Pconst_integer (_, Some _) (* 32n, 32L etc. *)
+  | Pconst_char _
+  | Pconst_float _ -> error "unsupported literal"
+
+and bound_var_of_ocaml arg =
+  let error fmt = error_at arg.ppat_loc fmt in
+  match arg.ppat_desc with
+    | Ppat_var name -> name.Location.txt
+    | _ -> error "a single bound variable was expected"
+
+and blackbox_of_ocaml exp =
+  match exp.pexp_desc with
+    | Pexp_constant (Pconst_string (str, _)) -> SBlackbox str
+    | _ -> SBlackbox "<expr>"

--- a/engine/ocaml_parser.ml
+++ b/engine/ocaml_parser.ml
@@ -1,0 +1,19 @@
+module Ocaml_ast = Migrate_parsetree.Ast_408
+
+let parse_implementation lexbuf : Ocaml_ast.Parsetree.structure =
+  let ast =
+    try Ocaml_common.Parse.implementation lexbuf
+    with exn ->
+      Ocaml_common.Location.report_exception Format.err_formatter exn;
+      exit 2 in
+  let convert =
+    let open Migrate_parsetree.Versions in
+    (migrate ocaml_current ocaml_408).copy_structure in
+  convert ast
+
+let try_parse file =
+  let input = open_in file in
+  Fun.protect ~finally:(fun () -> close_in input) @@ fun () ->
+  let lexbuf = Lexing.from_channel input in
+  Ocaml_ast.Location.init lexbuf file;
+  ignore (parse_implementation lexbuf)

--- a/engine/ocaml_parser.ml
+++ b/engine/ocaml_parser.ml
@@ -45,21 +45,16 @@ let error_at loc fmt =
 open Ast
 
 let rec ast_of_ocaml ~file (prog : ocaml_program) : source_program =
-  let definition =
-    match prog with
+  let definition_body =
+    let value_definition def = match def.pstr_desc with
+      | Pstr_value (_rec_flag, [binding]) -> Some binding
+      | _ -> None in
+    match List.filter_map value_definition prog with
     | [] | _ :: _ :: _ ->
        error_at (Location.in_file file)
-         "a single declaration was expected"
-    | [def] ->
-       def in
-  let definition_body =
-    match definition.pstr_desc with
-    | Pstr_value (_, [binding]) ->
-       binding.pvb_expr
-    | _ ->
-       error_at definition.pstr_loc
-         "a value declaration was expected"
-  in
+         "a single value declaration was expected"
+    | [binding] ->
+       binding.pvb_expr in
   let cases =
     match definition_body.pexp_desc with
     | Pexp_function cases ->


### PR DESCRIPTION
This PR plumbs in the OCaml parser, with a conversion pass to our simpler AST definition.

(`ocaml-compiler-libs` is the dependency that exposes the compiler internals, which I use for parsing into whatever AST definition the compiler is currently using. `ocaml-migrate-parsetree` is a robustness-improving project that provides the definitions of the AST of recent OCaml versions, and migration function between them. I convert the current-version AST resulting from parsing into a fixed version (currently 4.08), so that the code in the project will not have to change if the AST definitions change in the future. This plumbing work could be done in a separate project, I'm thinking of publishing a small package that does just this -- for AST parsing and pretty-printing.)
