### PR TITLE
Source accessors

### DIFF
--- a/engine/source_sym_engine.ml
+++ b/engine/source_sym_engine.ml
@@ -1,9 +1,13 @@
 open Ast
 
+type accessor =
+  | AcRoot
+  | AcField of accessor * int
+
 type constraint_tree =
   | Empty
   | Leaf of source_expr
-  | Node of (constructor * constraint_tree) list * constraint_tree
+  | Node of accessor * (constructor * constraint_tree) list * constraint_tree
 
 let string_of_source_expr = function
   | SBlackbox s -> s
@@ -11,7 +15,13 @@ let string_of_source_expr = function
 let print_result stree =
   let bprintf = Printf.bprintf
   in
-  let bprint_source_expr buf = function SBlackbox s -> bprintf buf "%s" s in
+  let bprint_source_expr buf = function
+    | SBlackbox s -> bprintf buf "%s" s
+  in
+  let rec bprint_accessor buf = function
+    | AcRoot -> bprintf buf "AcRoot"
+    | AcField (a, i) -> bprintf buf "%a.%d" bprint_accessor a i
+  in
   let rec bprint_list ~sep bprint buf = function
     | [] -> ()
     | [x] -> bprint buf x
@@ -39,10 +49,11 @@ let print_result stree =
       bprintf buf
         "Leaf='%a'"
         bprint_source_expr expr
-    | Node (k_cst_list, fallback_cst) ->
-      bprintf buf "Node:{\
+    | Node (ac, k_cst_list, fallback_cst) ->
+      bprintf buf "Node %a:{\
                    %a \
                    %t} Fallback: %a"
+        bprint_accessor ac
         (bprint_list ~sep:sep
            (fun buf (k,cst) -> bprintf buf "%t%a -> %t%a"
                sep
@@ -58,20 +69,27 @@ let print_result stree =
   BatIO.write_line BatIO.stdout (Buffer.contents buf)
 
 type row = pattern list * source_expr
+type matrix = accessor list * row list
 
 type group = {
   arity: int;
+  accessors: accessor list;
   rev_rows: row list ref;
 }
 
-let matrix_of_group { rev_rows; _ } =
-  List.rev !rev_rows
+let matrix_of_group { accessors; rev_rows; _ } : matrix =
+  (accessors, List.rev !rev_rows)
 
-let empty_group arity =
-  {
-    arity;
-    rev_rows = ref [];
-  }
+let empty_group acs arity =
+  match acs with
+  | [] -> assert false
+  | ac :: acs ->
+     let accessors = List.init arity (fun i -> AcField(ac, i)) @ acs in
+     {
+       arity;
+       accessors;
+       rev_rows = ref [];
+     }
 
 let group_add_children { arity; rev_rows; _ } children (rest, rhs) =
   assert (List.length children = arity);
@@ -81,9 +99,9 @@ let group_add_omegas { arity; rev_rows; _ } (rest, rhs) =
   let wildcards = List.init arity (fun _ -> (Wildcard : pattern)) in
   rev_rows := (List.rev_append wildcards rest, rhs) :: !rev_rows
 
-let group_constructors rows : (constructor * row list) list * row list =
+let group_constructors (acs, rows) : (constructor * matrix) list * matrix =
   let group_tbl : (constructor, group) Hashtbl.t = Hashtbl.create 42 in
-  let wildcard_group = empty_group 0 in
+  let wildcard_group = empty_group acs 0 in
   let rec collect_constructors : pattern list -> unit = function
     | [] -> ()
     | (pattern::ptl) ->
@@ -94,7 +112,7 @@ let group_constructors rows : (constructor * row list) list * row list =
       | Constructor (k, plist) ->
         if not (Hashtbl.mem group_tbl k) then begin
           let arity = List.length plist in
-          Hashtbl.add group_tbl k (empty_group arity)
+          Hashtbl.add group_tbl k (empty_group acs arity)
         end;
         collect_constructors ptl
   in
@@ -127,25 +145,25 @@ let group_constructors rows : (constructor * row list) list * row list =
   (constructor_matrices, wildcard_matrix)
 
 let sym_exec source =
-  let rec decompose (rows: row list) : constraint_tree =
-    match rows with
-    | [] -> assert false
-    | ([], expr)::[] -> Leaf expr
-    | ([], expr)::tl -> ignore tl; Leaf expr
-    | ((_pattern::_ptl), _expr)::_tl ->
-      let groups, fallback = group_constructors rows
-      in
-      let groups_evaluated =  groups
-                              |> List.map (fun (k, clause_lst) ->
-                                  k, decompose clause_lst)
+  let rec decompose matrix : constraint_tree =
+    match matrix with
+    | (_, []) -> assert false
+    | ([] as _no_acs, ([] as _no_columns, expr)::_) -> Leaf expr
+    | (_::_ as _accs, ([] as _no_columns, _)::_) -> assert false
+    | ([] as _no_accs, (_::_ as _columns, _)::_) -> assert false
+    | (ac_head::_ as _acs, ((_::_) as _columns, _)::_) ->
+      let groups, fallback = group_constructors matrix in
+      let groups_evaluated =
+        groups |> List.map (fun (k, submatrix) -> (k, decompose submatrix))
       in
       let fallback_evaluated = match fallback with
-        | [] -> Empty
-        | clause -> decompose clause
+        | (_, []) -> Empty
+        | nonempty_matrix -> decompose nonempty_matrix
       in
-      Node (groups_evaluated, fallback_evaluated)
+      Node (ac_head, groups_evaluated, fallback_evaluated)
     in
-    source.clauses |> List.map (fun (pattern, expr) -> ([pattern], expr)) |> decompose
+    let row_of_clause (pat, expr) = ([pat], expr) in
+    decompose ([AcRoot], List.map row_of_clause source.clauses)
 
 let eval source_ast =
   let result = sym_exec source_ast in


### PR DESCRIPTION
The first commit does not change the behavior, but it moves some code around to make the real change easier.

The second commit adds accessors. The idea is that a "matrix" is not just a list of rows anymore, it also contains an accessor list which gives the accessor/location of the values matched by the columns of the matrix (of the matrix rows). The size of the accessor list is equal to the number of columns of each row.

This "header" (it gives some meta-data for each column of the matrix) is maintained by the decomposition code. When we generate a `Node` node, we just get the first accessor of this header, and we know at which accessor the current decomposition is taking place.