### PR TITLE
Explicit Failure constraints

### DIFF
--- a/engine/ast.ml
+++ b/engine/ast.ml
@@ -4,7 +4,11 @@ type source_program  = {
   clauses: clause list;
 }
 and
-  clause = pattern * source_expr
+  clause = pattern * source_rhs
+and
+  source_rhs =
+  | Unreachable (* OCaml refutation clauses: | Foo -> . *)
+  | Expr of source_expr
 and
   pattern =
   | Wildcard

--- a/engine/ast.ml
+++ b/engine/ast.ml
@@ -48,6 +48,7 @@ and
   | Field of int * variable
   | Comparison of bop * sexpr * int
   | Isout of int * variable
+  | Match_failure
   | TBlackbox of target_blackbox
 and
   binding = variable * sexpr

--- a/engine/lexer.mll
+++ b/engine/lexer.mll
@@ -38,6 +38,8 @@ rule token = parse
 
   | "(" { LPAREN }
   | ")" { RPAREN }
+  | "[" { LBRACKET }
+  | "]" { RBRACKET }
   | "=" { EQUAL }
   | "=a" { EQUALA }
   | "!=" { BANGEQUAL }
@@ -58,6 +60,8 @@ rule token = parse
   | "let" { LET }
   | "makeblock" { MAKEBLOCK }
   | "setglobal" { SETGLOBAL }
+  | "global" { GLOBAL }
+  | "raise" { RAISE }
   | "switch" { SWITCH }
   | "switch*" { SWITCHSTAR }
   | "tag" { TAGSYMBOL }
@@ -74,6 +78,7 @@ rule token = parse
   | (lowercase identchar* '/' int) as ident { LIDENT ident }
   | ('*' lowercase identchar* '*' '/' int) as ident { LIDENT ident }
   | (uppercase identchar* '!') as ident { UIDENT ident }
+  | (uppercase identchar* '/' int '!') as ident { UIDENT ident }
 
   | eof { EOF }
 

--- a/engine/ocaml_parser.ml
+++ b/engine/ocaml_parser.ml
@@ -84,8 +84,13 @@ and clause_of_ocaml { pc_lhs = pattern; pc_guard = guard; pc_rhs = expr } : clau
      Location.alert ~kind:"Warning" guard.pexp_loc "Ignored pattern guard";
   end;
   let pattern = pattern_of_ocaml pattern in
-  let expr = blackbox_of_ocaml expr in
-  (pattern, expr)
+  let rhs = rhs_of_ocaml expr in
+  (pattern, rhs)
+
+and rhs_of_ocaml expr : source_rhs =
+  match expr.pexp_desc with
+    | Pexp_unreachable -> Unreachable
+    | _ -> Expr (blackbox_of_ocaml expr)
 
 and pattern_of_ocaml p : Ast.pattern =
   let error fmt = error_at p.ppat_loc fmt in

--- a/examples/example9.lambda
+++ b/examples/example9.lambda
@@ -1,0 +1,4 @@
+(setglobal Example9!
+  (let (test/80 = (function param/81 : int (if (!= param/81 0) 0 1)))
+    (makeblock 0 test/80)))
+

--- a/examples/example9.lambda
+++ b/examples/example9.lambda
@@ -1,4 +1,7 @@
 (setglobal Example9!
-  (let (test/80 = (function param/81 : int (if (!= param/81 0) 0 1)))
+  (let
+    (test/80 =
+      (function param/81
+        (if (!= param/81 0) 0 1)))
     (makeblock 0 test/80)))
 

--- a/examples/example9.ml
+++ b/examples/example9.ml
@@ -1,0 +1,6 @@
+let test = function
+  | true -> 0
+  | false -> 1
+  | _ -> .
+    (* Unreachable; if this annotation was incorrect,
+       the OCaml compiler would error at pattern-checking-time *)

--- a/examples/example9bis.lambda
+++ b/examples/example9bis.lambda
@@ -1,0 +1,10 @@
+(setglobal Example9bis!
+  (let
+    (test/80 =
+       (function param/81
+         (if (!= param/81 0) 0
+           (raise
+             (makeblock 0 (global Match_failure/18!)
+               [0: "examples/example9bis.ml" 1 11])))))
+    (makeblock 0 test/80)))
+

--- a/examples/example9bis.ml
+++ b/examples/example9bis.ml
@@ -1,0 +1,3 @@
+let test = function
+  | true -> 0
+  (* we expect a Match_failure node for 'false' in the lambda representation *)


### PR DESCRIPTION
As briefly discussed by email, we should distinguish empty constraint trees that mean "no value can possibly come here" from "any value coming here results in a match-failure error". This is tentatively done in this PR (but it should eventually be improved with analysis of which sets-of-constructor-groups are "closed", and which target constraints are unsatisfiable). See the comment on source constraints for details/examples.