### PR TITLE
a more semantic representation of target piops

### DIFF
--- a/engine/dune
+++ b/engine/dune
@@ -9,5 +9,5 @@
 
 (executable
  (name main)
- (libraries batteries ocaml-compiler-libs.common ocaml-migrate-parsetree)
+ (libraries batteries ocaml-compiler-libs.common ocaml-migrate-parsetree diet)
  )

--- a/engine/merge_accessors.ml
+++ b/engine/merge_accessors.ml
@@ -3,9 +3,9 @@ open Ast
 type constraint_tree =
   | Failure
   | Leaf of Ast.target_blackbox
-  | Node of (pi * constraint_tree) list * (pi list * constraint_tree) option
+  | Node of sym_value * (domain * constraint_tree) list * (domain * constraint_tree) option
 and
-  pi = { var: sym_value; op: Target_sym_engine.piop }
+  domain = Target_sym_engine.domain
 and
   sym_function = variable * constraint_tree
 and
@@ -17,43 +17,30 @@ and
   | AcTag of sym_value * int
 
 let rec merge : Target_sym_engine.constraint_tree -> constraint_tree =
-  let rec map_sym_value (pi: Target_sym_engine.pi) : pi =
-    match pi.var with
-    | AcRoot v -> {var=AcRoot v; op=pi.op}
-    | AcField (s, i) ->
-      let inner = map_sym_value {var=s; op=pi.op} in
-      {var=AcField (inner.var, i); op=inner.op}
-    | AcTag (s, i) ->
-      let inner = map_sym_value {var=s; op=pi.op} in
-      {var=AcTag (inner.var, i); op=inner.op}
+  let rec map_sym_value : Target_sym_engine.sym_value -> sym_value = function
+    | AcRoot v -> AcRoot v
+    | AcField (s, i) -> AcField(map_sym_value s, i)
+    | AcTag (s, i) -> AcTag(map_sym_value s, i)
     | AcAdd (_, _) -> assert false
   in
-  let rec subst_acadd (pi: Target_sym_engine.pi) : pi =
-    match pi.var with
-    | AcAdd (svalue, a) -> let op':Target_sym_engine.piop =  match pi.op with
-        | Tag i -> Tag (a+i)
-        | NotTag i -> NotTag (a+i)
-        | Int i -> Int (a+i)
-        | NotInt i -> NotInt (a+i)
-        | Ge i -> Ge (a+i)
-        | Gt i -> Gt (a+i)
-        | Le i -> Le (a+i)
-        | Lt i -> Lt (a+i)
-        | Eq i -> Eq (a+i)
-        | Nq i -> Nq (a+i)
-        | Isout i -> Isout (a+i)
-        | Isin i -> Isin (a+i)
-      in
-      subst_acadd {var=svalue; op=op'}
-    | _ -> map_sym_value pi
+  let rec split : Target_sym_engine.sym_value -> sym_value * int = function
+    | AcAdd (s, i) ->
+       let (s, offset) = split s in (s, offset+i)
+    | other -> (map_sym_value other, 0)
   in
+  let shift_domain offset domain =
+    let open Target_sym_engine in
+    (* Note: AcAdd is only use on integer concrete values,
+       not tags. Thus, we only shift the set of possible integer values,
+       and preserve the set of possible tags. *)
+    {
+      int = Domain.Set.shift (-offset) domain.int;
+      tag = domain.tag;
+    } in
   function
   | Target_sym_engine.Failure -> Failure
   | Target_sym_engine.Leaf l -> Leaf l
-  | Target_sym_engine.Node (children, fallback) -> 
-    let subst_children = List.map (fun (pi, c_tree) -> (subst_acadd pi, merge c_tree))
-    in
-    let subst_fallback = Option.map (fun (pilst, c_tree) ->
-        (pilst |> List.map subst_acadd, merge c_tree))
-    in
-    Node (subst_children children, subst_fallback fallback)
+  | Target_sym_engine.Node (var, children, fallback) ->
+    let (var, offset) = split var in
+    let subst (dom, c_tree) = (shift_domain offset dom, merge c_tree) in
+    Node (var, List.map subst children, Option.map subst fallback)

--- a/engine/target_sym_engine.ml
+++ b/engine/target_sym_engine.ml
@@ -38,7 +38,7 @@ and
 
 module Domain = struct
   module Set = struct
-    let set interval = IntSet.add interval IntSet.empty
+    let set interv = IntSet.add interv IntSet.empty
     let point n = set (IntSet.Interval.make n n)
     let interval low high = set (IntSet.Interval.make low high)
 
@@ -55,6 +55,26 @@ module Domain = struct
 
     let union = IntSet.union
     let inter = IntSet.inter
+
+    let shift n set =
+      let open IntSet in
+      let shift_interval n intev =
+        let open Interval in
+        make (x intev + n) (y intev + n) in
+      let on_interval intev acc =
+        add (shift_interval n intev) acc in
+      IntSet.fold on_interval set IntSet.empty
+      (* TODO: this definition is incorrect in the case of overflows;
+         for example
+           x+1 <= 2
+         gets translated to the set
+           x+2 ∈ [min_int; 2]
+         The version shifted by -1 should not be
+           x ∈ [min_int-2; 0]
+           (which is the nonsensical x ∈ [max_int; 1])
+         but rather
+           x ∈ [min_int; 0] ∪ [max_int-1; max_int]
+       *)
 
     let to_string set =
       let on_interval interv acc =


### PR DESCRIPTION
With this commit, target symbolic constraints are represented directly
by their "domain", that is the set of all possible concrete values.

The concrete value of an accessor may be a value of the form (Int n)
or a value of the form (Tag n), so in the general case a symbolic
value may belong to a set of possible integers *and* a set of possible
tags: a pair of sets.

Intuitively, one can efficiently represent those sets because they are
created by simple operations (equalities and comparisons
with integers), negation and intersection, so they remain unions of
intervals that can be implemented efficiently. (We use an external
library called Diet to represent arbitrary unions of integer
intervals.)

It should now be very simple to implement logical simplifications on
those domains (intersection, equality or inclusion checking, etc.), by
directly using the operations on the underlying sets.
