### PR TITLE
accessor type definition in module Ast

### DIFF
--- a/engine/ast.ml
+++ b/engine/ast.ml
@@ -82,6 +82,10 @@ type source_constraint =
   | Constructor of constructor * source_constraint list
   | As of source_constraint * variable
 
+type accessor =
+  | AcRoot
+  | AcField of accessor * int
+
 let sexpr_of_bexpr : bexpr -> sexpr = function
 | Comparison (op, exp, n) -> Comparison (op, exp, n)
 | Field (i, v) -> Field (i, v)

--- a/engine/merge_accessors.ml
+++ b/engine/merge_accessors.ml
@@ -10,14 +10,10 @@ and
   sym_function = variable * constraint_tree
 and
   sym_catch = exitpoint * variable list * constraint_tree
-and
-  accessor =
-  | AcRoot of variable
-  | AcField of accessor * int
 
 let rec merge : Target_sym_engine.constraint_tree -> constraint_tree =
   let rec map_accessor : Target_sym_engine.accessor -> accessor = function
-    | AcRoot v -> AcRoot v
+    | AcRoot _ -> AcRoot
     | AcField (s, i) -> AcField(map_accessor s, i)
     | AcAdd (_, _) -> assert false
   in

--- a/engine/source_sym_engine.ml
+++ b/engine/source_sym_engine.ml
@@ -1,9 +1,5 @@
 open Ast
 
-type accessor =
-  | AcRoot
-  | AcField of accessor * int
-
 type constraint_tree =
   | Unreachable
   | Failure


### PR DESCRIPTION
Now source_sym_engine and merge_accessor share the same type
definition for accessors