### PR TITLE
Parse type declarations to build type information

### DIFF
--- a/engine/ast.ml
+++ b/engine/ast.ml
@@ -1,6 +1,7 @@
 [@@@ warning "-30"]
 
 type source_program  = {
+  type_decls: type_decl list;
   clauses: clause list;
 }
 and
@@ -17,7 +18,7 @@ and
   | As of pattern * variable
 and
   constructor =
-  | Variant of string
+  | Variant of variant_name
   | Int of int
   | Bool of bool
   | String of string
@@ -25,11 +26,24 @@ and
   | Nil
   | Cons
 and
+  variant_name = string
+and
   variable = string
-and 
+and
   source_expr = SBlackbox of source_blackbox
 and
   source_blackbox = string
+and type_decl = {
+  name: type_name;
+  constructors: constructor_decl list;
+}
+and
+  type_name = string
+and constructor_decl = {
+  constructor_name: variant_name;
+  args: type_expr list;
+}
+and type_expr = unit (* we only care about the arity for now *)
 
 type target_program = sexpr
 and
@@ -38,7 +52,7 @@ and
   | Int of int
   | Bool of bool
   | String of string
-  | Addition of int * variable 
+  | Addition of int * variable
   | Function of variable * sexpr
   | Let of binding list * sexpr
   | Catch of sexpr * exitpoint * variable list * sexpr

--- a/engine/source_env.ml
+++ b/engine/source_env.ml
@@ -1,0 +1,33 @@
+open Ast
+
+module ConstructorMap = Map.Make(String)
+
+type type_env = (type_decl * constructor_decl) ConstructorMap.t
+
+let build_type_env type_decls =
+  let add_type_decl env type_decl =
+    let add_constructor env constructor =
+      ConstructorMap.add constructor.constructor_name (type_decl, constructor) env in
+    List.fold_left add_constructor env type_decl.constructors in
+  List.fold_left add_type_decl ConstructorMap.empty type_decls
+
+type constructor_repr =
+  | Int of int
+  | Tag of int
+
+type type_repr_env = constructor_repr ConstructorMap.t
+
+let build_type_repr_env type_decls =
+  let add_type_decl env type_decl =
+    let add_constructor (next_int, next_tag, env) constructor =
+      let next_int, next_tag, repr =
+        if constructor.args = [] then
+          (next_int + 1, next_tag, Int next_int)
+        else
+          (next_int, next_tag + 1, Tag next_tag)
+      in
+      (next_int, next_tag,
+       ConstructorMap.add constructor.constructor_name repr env) in
+    let (_, _, env) = List.fold_left add_constructor (0, 0, env) type_decl.constructors in
+    env in
+  List.fold_left add_type_decl ConstructorMap.empty type_decls

--- a/engine/source_env.ml
+++ b/engine/source_env.ml
@@ -11,6 +11,15 @@ let build_type_env type_decls =
     List.fold_left add_constructor env type_decl.constructors in
   List.fold_left add_type_decl ConstructorMap.empty type_decls
 
+let constructor_arity type_env : constructor -> int = function
+  | Int _ | Bool _ | String _ -> 0
+  | Tuple n -> n
+  | Nil -> 0
+  | Cons -> 2
+  | Variant name ->
+     let constructor_decl = ConstructorMap.find name type_env |> snd in
+     List.length constructor_decl.args
+
 type constructor_repr =
   | Int of int
   | Tag of int

--- a/engine/source_sym_engine.ml
+++ b/engine/source_sym_engine.ml
@@ -132,7 +132,7 @@ let group_add_omegas { arity; rev_rows; _ } (rest, rhs) =
   let wildcards = List.init arity (fun _ -> (Wildcard : pattern)) in
   rev_rows := (List.rev_append wildcards rest, rhs) :: !rev_rows
 
-let group_constructors (acs, rows) : (constructor * matrix) list * matrix =
+let group_constructors type_env (acs, rows) : (constructor * matrix) list * matrix =
   let group_tbl : (constructor, group) Hashtbl.t = Hashtbl.create 42 in
   let wildcard_group = empty_group acs 0 in
   let rec collect_constructors : pattern list -> unit = function
@@ -142,9 +142,9 @@ let group_constructors (acs, rows) : (constructor * matrix) list * matrix =
       | Wildcard -> ()
       | Or (p1, p2) -> collect_constructors (p1::p2::ptl)
       | As (p, _) -> collect_constructors (p::ptl)
-      | Constructor (k, plist) ->
+      | Constructor (k, _plist) ->
         if not (Hashtbl.mem group_tbl k) then begin
-          let arity = List.length plist in
+          let arity = Source_env.constructor_arity type_env k in
           Hashtbl.add group_tbl k (empty_group acs arity)
         end;
         collect_constructors ptl
@@ -178,6 +178,7 @@ let group_constructors (acs, rows) : (constructor * matrix) list * matrix =
   (constructor_matrices, wildcard_matrix)
 
 let sym_exec source =
+  let type_env = Source_env.build_type_env source.type_decls in
   let rec decompose matrix : constraint_tree =
     match matrix with
     | (_, []) -> assert false
@@ -189,7 +190,7 @@ let sym_exec source =
     | (_::_ as _accs, ([] as _no_columns, _)::_) -> assert false
     | ([] as _no_accs, (_::_ as _columns, _)::_) -> assert false
     | (ac_head::_ as _acs, ((_::_) as _columns, _)::_) ->
-      let groups, fallback = group_constructors matrix in
+      let groups, fallback = group_constructors type_env matrix in
       let groups_evaluated =
         groups |> List.map (fun (k, submatrix) -> (k, decompose submatrix))
       in


### PR DESCRIPTION
This PR parses type declarations in .ml files, and uses it to compute the arities of variant constructor (instead of the sort-of-hack we were using before). It also puts code in place to compute the target representation of a variant constructor (integer or tag?), which @FraMecca will need to translate source piops into target domains.