### PR TITLE
rename: node -> switch, constraint_tree -> decision_tree

### DIFF
--- a/engine/main.ml
+++ b/engine/main.ml
@@ -1,7 +1,7 @@
 type source_result = {
     type_decls: Ast.type_decl list;
     type_env: (Ast.type_decl * Ast.constructor_decl) Source_env.ConstructorMap.t;
-    source_tree: Source_sym_engine.constraint_tree;
+    source_tree: Source_sym_engine.decision_tree;
 }
 
 let source_exec file =
@@ -24,8 +24,8 @@ let source_exec file =
   }
 
 type target_result = {
-  target_tree_with_accessors: Target_sym_engine.constraint_tree;
-  target_tree: Merge_accessors.constraint_tree;
+  target_tree_with_accessors: Target_sym_engine.decision_tree;
+  target_tree: Merge_accessors.decision_tree;
 }
 
 let target_exec file =


### PR DESCRIPTION
I don't think this need a time consuming review, it was done using sed.
 The goal is to use the same terminology as the workshop submission.